### PR TITLE
check for CATKIN_ENABLE_TESTING

### DIFF
--- a/gmapping/CMakeLists.txt
+++ b/gmapping/CMakeLists.txt
@@ -23,28 +23,30 @@ install(TARGETS slam_gmapping
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
-if(TARGET tests)
-  add_executable(gmapping-rtest EXCLUDE_FROM_ALL test/rtest.cpp)
-  target_link_libraries(gmapping-rtest ${catkin_LIBRARIES} ${GTEST_LIBRARIES})
-  add_dependencies(tests gmapping-rtest)
-endif()
+if(CATKIN_ENABLE_TESTING)
+  if(TARGET tests)
+    add_executable(gmapping-rtest EXCLUDE_FROM_ALL test/rtest.cpp)
+    target_link_libraries(gmapping-rtest ${catkin_LIBRARIES} ${GTEST_LIBRARIES})
+    add_dependencies(tests gmapping-rtest)
+  endif()
 
-# Need to make the tests more robust; currently the output map can differ
-# substantially between runs.
-catkin_download_test_data(
-  ${PROJECT_NAME}_basic_localization_stage_indexed.bag
-  http://pr.willowgarage.com/data/gmapping/basic_localization_stage_indexed.bag
-  DESTINATION ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/test
-  MD5 322a0014f47bcfbb0ad16a317738b0dc)
-catkin_download_test_data(
-  ${PROJECT_NAME}_hallway_slow_2011-03-04-21-41-33.bag
-  http://pr.willowgarage.com/data/gmapping/hallway_slow_2011-03-04-21-41-33.bag
-  DESTINATION ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/test
-  MD5 e772b89713693adc610f4c5b96f5dc03)
-catkin_download_test_data(
-  ${PROJECT_NAME}_basic_localization_stage_groundtruth.pgm
-  http://pr.willowgarage.com/data/gmapping/basic_localization_stage_groundtruth.pgm
-  DESTINATION ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/test
-  MD5 abf208f721053915145215b18c98f9b3)
-add_rostest(test/basic_localization_stage.launch)
-add_rostest(test/basic_localization_laser_different_beamcount.test)
+  # Need to make the tests more robust; currently the output map can differ
+  # substantially between runs.
+  catkin_download_test_data(
+    ${PROJECT_NAME}_basic_localization_stage_indexed.bag
+    http://pr.willowgarage.com/data/gmapping/basic_localization_stage_indexed.bag
+    DESTINATION ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/test
+    MD5 322a0014f47bcfbb0ad16a317738b0dc)
+  catkin_download_test_data(
+    ${PROJECT_NAME}_hallway_slow_2011-03-04-21-41-33.bag
+    http://pr.willowgarage.com/data/gmapping/hallway_slow_2011-03-04-21-41-33.bag
+    DESTINATION ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/test
+    MD5 e772b89713693adc610f4c5b96f5dc03)
+  catkin_download_test_data(
+    ${PROJECT_NAME}_basic_localization_stage_groundtruth.pgm
+    http://pr.willowgarage.com/data/gmapping/basic_localization_stage_groundtruth.pgm
+    DESTINATION ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/test
+    MD5 abf208f721053915145215b18c98f9b3)
+  add_rostest(test/basic_localization_stage.launch)
+  add_rostest(test/basic_localization_laser_different_beamcount.test)
+endif()

--- a/gmapping/package.xml
+++ b/gmapping/package.xml
@@ -12,7 +12,7 @@
 
   <url>http://ros.org/wiki/gmapping</url>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
   <build_depend>nav_msgs</build_depend>
   <build_depend>openslam_gmapping</build_depend>


### PR DESCRIPTION
Since version 0.5.68, catkin provides to optionally configure tests. This commit adjusts the CMakeLists.txt to opt-in the tests.
