### PR TITLE
Avoid using outdated laser scans

### DIFF
--- a/gmapping/src/slam_gmapping.h
+++ b/gmapping/src/slam_gmapping.h
@@ -74,6 +74,7 @@ class SlamGMapping
 
     int laser_count_;
     int throttle_scans_;
+    double scan_tolerance_;
 
     boost::thread* transform_thread_;
 


### PR DESCRIPTION
I have quite bad experiences while using this for mapping, and I found that one of the reasons is because of outdated scans. So I tried reducing the queue for laser scans to one, so unprocessed scans don't accumulate and we always use the latest available.

I added an extra check on how old latest scan is: scan_tolerance parameter. A negative value disables it.

I don't understand deeply how gmapping works, so feel free to discard this pull request if it's misguided or useless.
