### PR TITLE
Update slam_gmapping.cpp

### DIFF
--- a/gmapping/src/slam_gmapping.cpp
+++ b/gmapping/src/slam_gmapping.cpp
@@ -397,7 +397,7 @@ SlamGMapping::initMapper(const sensor_msgs::LaserScan& scan)
 
   gsp_->setMotionModelParameters(srr_, srt_, str_, stt_);
   gsp_->setUpdateDistances(linearUpdate_, angularUpdate_, resampleThreshold_);
-//  gsp_->setUpdatePeriod(temporalUpdate_);
+  gsp_->setUpdatePeriod(temporalUpdate_);
   gsp_->setgenerateMap(false);
   gsp_->GridSlamProcessor::init(particles_, xmin_, ymin_, xmax_, ymax_,
                                 delta_, initialPose);


### PR DESCRIPTION
Reenabled temporal update.
I can't see why it was commented out anyway. The commit where it was commented out was commit "8f48572" on Jun 27, 2013 with message "catkinize slam_gmapping". Maybe someone has more information on this matter?
