### PR TITLE
Fixed typo in slam_gmapping_pr2.launch

### DIFF
--- a/gmapping/launch/slam_gmapping_pr2.launch
+++ b/gmapping/launch/slam_gmapping_pr2.launch
@@ -2,7 +2,7 @@
     <param name="use_sim_time" value="true"/>
     <node pkg="gmapping" type="slam_gmapping" name="slam_gmapping" output="screen">
       <remap from="scan" to="base_scan"/>
-      <param name="map_udpate_interval" value="5.0"/>
+      <param name="map_update_interval" value="5.0"/>
       <param name="maxUrange" value="16.0"/>
       <param name="sigma" value="0.05"/>
       <param name="kernelSize" value="1"/>


### PR DESCRIPTION
Fixed a typo in the launchfile in the parameter "map_update_interval".
It took me like forever to find the reason why my map only got updated every ~5 seconds regardless the update interval I set in the launchfile...
