### PR TITLE
[new feature] replay on bag file

### DIFF
--- a/gmapping/CMakeLists.txt
+++ b/gmapping/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 project(gmapping)
 
-find_package(catkin REQUIRED nav_msgs openslam_gmapping roscpp rostest tf)
+find_package(catkin REQUIRED nav_msgs openslam_gmapping roscpp rostest tf rosbag)
 
 find_package(Boost REQUIRED signals)
 
@@ -17,7 +17,15 @@ if(catkin_EXPORTED_TARGETS)
   add_dependencies(slam_gmapping ${catkin_EXPORTED_TARGETS})
 endif()
 
-install(TARGETS slam_gmapping
+add_executable(slam_gmapping_replay src/slam_gmapping.cpp src/replay.cpp)
+target_link_libraries(slam_gmapping_replay ${Boost_LIBRARIES} ${catkin_LIBRARIES})
+if(catkin_EXPORTED_TARGETS)
+  add_dependencies(slam_gmapping_replay ${catkin_EXPORTED_TARGETS})
+endif()
+
+
+
+install(TARGETS slam_gmapping slam_gmapping_replay
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/gmapping/src/replay.cpp
+++ b/gmapping/src/replay.cpp
@@ -1,0 +1,61 @@
+/* Author: Laurent George */
+
+#include <ros/ros.h>
+
+#include "slam_gmapping.h"
+#include "boost/program_options.hpp"
+
+int
+main(int argc, char** argv)
+{
+    /** Define and parse the program options 
+     */ 
+    namespace po = boost::program_options; 
+    po::options_description desc("Options"); 
+    desc.add_options() 
+    ("help", "Print help messages") 
+    ("scan_topic",  po::value<std::string>()->default_value("/scan") ,"topic that contains the laserScan in the rosbag")
+    ("bag_filename", po::value<std::string>()->required(), "ros bag filename") 
+    ("seed", po::value<unsigned long int>()->default_value(0), "seed")
+    ("max_duration_buffer", po::value<unsigned long int>()->default_value(99999), "max tf buffer duration") ;
+    
+    po::variables_map vm; 
+    try 
+    { 
+        po::store(po::parse_command_line(argc, argv, desc),  
+                  vm); // can throw 
+        
+        /** --help option 
+         */ 
+        if ( vm.count("help")  ) 
+        { 
+            std::cout << "Basic Command Line Parameter App" << std::endl 
+            << desc << std::endl; 
+            return 0; 
+        } 
+        
+        po::notify(vm); // throws on error, so do after help in case 
+        // there are any problems 
+    } 
+    catch(po::error& e) 
+    { 
+        std::cerr << "ERROR: " << e.what() << std::endl << std::endl; 
+        std::cerr << desc << std::endl; 
+        return -1; 
+    } 
+    
+    std::string bag_fname = vm["bag_filename"].as<std::string>();
+    std::string scan_topic = vm["scan_topic"].as<std::string>();
+    unsigned long int seed = vm["seed"].as<unsigned long int>();
+    unsigned long int max_duration_buffer = vm["max_duration_buffer"].as<unsigned long int>();
+    
+    ros::init(argc, argv, "slam_gmapping");
+    SlamGMapping *  gn = new SlamGMapping(bag_fname, scan_topic, seed, max_duration_buffer) ;
+    std::cout << "replay stop, press ctrl-c to quit"  << std::endl;
+    ros::spin(); // wait so user can save the map
+    return(0);
+    
+    
+}
+
+

--- a/gmapping/src/slam_gmapping.h
+++ b/gmapping/src/slam_gmapping.h
@@ -34,6 +34,7 @@ class SlamGMapping
 {
   public:
     SlamGMapping();
+    SlamGMapping(const std::string bag_filename, const std::string scan_topic, unsigned long int seed, unsigned long int max_duration_buffer);
     ~SlamGMapping();
 
     void publishTransform();
@@ -42,8 +43,9 @@ class SlamGMapping
     bool mapCallback(nav_msgs::GetMap::Request  &req,
                      nav_msgs::GetMap::Response &res);
     void publishLoop(double transform_publish_period);
-
+    void init();
   private:
+    void process_bag(const std::string bag_filename, const std::string scan_topic);
     ros::NodeHandle node_;
     ros::Publisher entropy_publisher_;
     ros::Publisher sst_;


### PR DESCRIPTION
The aim is to provide a way to get exactly the same map after running
gmapping multiple times on the same rosbag file. It wasn't possible with the
tool 'rosbag play', indeed one missing laser scan could provide really
different results.

Moreover, this modification allow to process rosbag offline at the maximum
speed with the guarantee that all lasers scans are processed. It is
 useful in automatic tests and when finding optimal gmapping parameters with a script.

Example usage:
    rosrun gmapping slam_gmapping_replay --scan_topic=/scan --bag_filename=/tmp/in.bag _particles:=100 _maxUrange:=10

more options:
    rosrun gmapping slam_gmapping_replay --help
