### PR TITLE
Feature replay on rosbag

### DIFF
--- a/gmapping/CMakeLists.txt
+++ b/gmapping/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 project(gmapping)
 
-find_package(catkin REQUIRED nav_msgs openslam_gmapping roscpp rostest tf rosbag)
+find_package(catkin REQUIRED nav_msgs openslam_gmapping roscpp rostest tf rosbag_storage)
 
 find_package(Boost REQUIRED signals)
 

--- a/gmapping/CMakeLists.txt
+++ b/gmapping/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 project(gmapping)
 
-find_package(catkin REQUIRED nav_msgs openslam_gmapping roscpp rostest tf)
+find_package(catkin REQUIRED nav_msgs openslam_gmapping roscpp rostest tf rosbag)
 
 find_package(Boost REQUIRED signals)
 
@@ -17,7 +17,13 @@ if(catkin_EXPORTED_TARGETS)
   add_dependencies(slam_gmapping ${catkin_EXPORTED_TARGETS})
 endif()
 
-install(TARGETS slam_gmapping
+add_executable(slam_gmapping_replay src/slam_gmapping.cpp src/replay.cpp)
+target_link_libraries(slam_gmapping_replay ${Boost_LIBRARIES} ${catkin_LIBRARIES})
+if(catkin_EXPORTED_TARGETS)
+add_dependencies(slam_gmapping_replay ${catkin_EXPORTED_TARGETS})
+endif()
+
+install(TARGETS slam_gmapping slam_gmapping_replay
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
@@ -48,5 +54,6 @@ if(CATKIN_ENABLE_TESTING)
     DESTINATION ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/test
     MD5 abf208f721053915145215b18c98f9b3)
   add_rostest(test/basic_localization_stage.launch)
+  add_rostest(test/basic_localization_stage_replay.launch)
   add_rostest(test/basic_localization_laser_different_beamcount.test)
 endif()

--- a/gmapping/src/main.cpp
+++ b/gmapping/src/main.cpp
@@ -26,7 +26,7 @@ main(int argc, char** argv)
   ros::init(argc, argv, "slam_gmapping");
 
   SlamGMapping gn;
-
+  gn.startLiveSlam();
   ros::spin();
 
   return(0);

--- a/gmapping/src/replay.cpp
+++ b/gmapping/src/replay.cpp
@@ -1,5 +1,19 @@
-/* Author: Laurent George */
-
+/*
+ * Copyright 2015 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
 #include <ros/ros.h>
 
 #include "slam_gmapping.h"
@@ -52,7 +66,8 @@ main(int argc, char** argv)
     ros::init(argc, argv, "slam_gmapping");
     SlamGMapping *  gn = new SlamGMapping(seed, max_duration_buffer) ;
     gn->startReplay(bag_fname, scan_topic);
-    std::cout << "replay stop"  << std::endl;
+    ROS_INFO("replay stopped.");
+
     ros::spin(); // wait so user can save the map
     return(0);
     

--- a/gmapping/src/replay.cpp
+++ b/gmapping/src/replay.cpp
@@ -14,10 +14,13 @@
  * limitations under the License.
  *
 */
-#include <ros/ros.h>
-
 #include "slam_gmapping.h"
-#include "boost/program_options.hpp"
+
+#include <iostream>
+#include <string>
+
+#include <boost/program_options.hpp>
+#include <ros/ros.h>
 
 int
 main(int argc, char** argv)
@@ -64,8 +67,8 @@ main(int argc, char** argv)
     unsigned long int max_duration_buffer = vm["max_duration_buffer"].as<unsigned long int>();
     
     ros::init(argc, argv, "slam_gmapping");
-    SlamGMapping *  gn = new SlamGMapping(seed, max_duration_buffer) ;
-    gn->startReplay(bag_fname, scan_topic);
+    SlamGMapping gn(seed, max_duration_buffer) ;
+    gn.startReplay(bag_fname, scan_topic);
     ROS_INFO("replay stopped.");
 
     ros::spin(); // wait so user can save the map

--- a/gmapping/src/replay.cpp
+++ b/gmapping/src/replay.cpp
@@ -1,0 +1,61 @@
+/* Author: Laurent George */
+
+#include <ros/ros.h>
+
+#include "slam_gmapping.h"
+#include "boost/program_options.hpp"
+
+int
+main(int argc, char** argv)
+{
+    /** Define and parse the program options 
+     */ 
+    namespace po = boost::program_options; 
+    po::options_description desc("Options"); 
+    desc.add_options() 
+    ("help", "Print help messages") 
+    ("scan_topic",  po::value<std::string>()->default_value("/scan") ,"topic that contains the laserScan in the rosbag")
+    ("bag_filename", po::value<std::string>()->required(), "ros bag filename") 
+    ("seed", po::value<unsigned long int>()->default_value(0), "seed")
+    ("max_duration_buffer", po::value<unsigned long int>()->default_value(99999), "max tf buffer duration") ;
+    
+    po::variables_map vm; 
+    try 
+    { 
+        po::store(po::parse_command_line(argc, argv, desc),  
+                  vm); // can throw 
+        
+        /** --help option 
+         */ 
+        if ( vm.count("help")  ) 
+        { 
+            std::cout << "Basic Command Line Parameter App" << std::endl 
+            << desc << std::endl; 
+            return 0; 
+        } 
+        
+        po::notify(vm); // throws on error, so do after help in case 
+        // there are any problems 
+    } 
+    catch(po::error& e) 
+    { 
+        std::cerr << "ERROR: " << e.what() << std::endl << std::endl; 
+        std::cerr << desc << std::endl; 
+        return -1; 
+    } 
+    
+    std::string bag_fname = vm["bag_filename"].as<std::string>();
+    std::string scan_topic = vm["scan_topic"].as<std::string>();
+    unsigned long int seed = vm["seed"].as<unsigned long int>();
+    unsigned long int max_duration_buffer = vm["max_duration_buffer"].as<unsigned long int>();
+    
+    ros::init(argc, argv, "slam_gmapping");
+    SlamGMapping *  gn = new SlamGMapping(seed, max_duration_buffer) ;
+    gn->startReplay(bag_fname, scan_topic);
+    std::cout << "replay stop"  << std::endl;
+    ros::spin(); // wait so user can save the map
+    return(0);
+    
+    
+}
+

--- a/gmapping/src/slam_gmapping.cpp
+++ b/gmapping/src/slam_gmapping.cpp
@@ -259,7 +259,7 @@ void SlamGMapping::startLiveSlam()
   transform_thread_ = new boost::thread(boost::bind(&SlamGMapping::publishLoop, this, transform_publish_period_));
 }
 
-void SlamGMapping::startReplay(std::string bag_fname, std::string scan_topic)
+void SlamGMapping::startReplay(const std::string & bag_fname, std::string scan_topic)
 {
   double transform_publish_period;
   ros::NodeHandle private_nh_("~");
@@ -294,10 +294,8 @@ void SlamGMapping::startReplay(std::string bag_fname, std::string scan_topic)
   
   topics_scan.push_back(scan_topic); 
   rosbag::View viewall(bag, rosbag::TopicQuery(topics_scan));
-  int i = 0;
   foreach(rosbag::MessageInstance const m, viewall)
   {
-    i+=1 ;
     sensor_msgs::LaserScan::ConstPtr s = m.instantiate<sensor_msgs::LaserScan>();
     if (s != NULL) {
       if (!(ros::Time(s->header.stamp)).is_zero())

--- a/gmapping/src/slam_gmapping.cpp
+++ b/gmapping/src/slam_gmapping.cpp
@@ -119,6 +119,11 @@ Initial map dimensions and resolution:
 #include "gmapping/sensor/sensor_range/rangesensor.h"
 #include "gmapping/sensor/sensor_odometry/odometrysensor.h"
 
+#include <rosbag/bag.h>
+#include <rosbag/view.h>
+#include <boost/foreach.hpp>
+#define foreach BOOST_FOREACH
+
 // compute linear index for given map coords
 #define MAP_IDX(sx, i, j) ((sx) * (j) + (i))
 
@@ -127,6 +132,13 @@ SlamGMapping::SlamGMapping():
   laser_count_(0), private_nh_("~"), transform_thread_(NULL)
 {
   seed_ = time(NULL);
+  init();
+}
+
+SlamGMapping::SlamGMapping(long unsigned int seed, long unsigned int max_duration_buffer):
+  map_to_odom_(tf::Transform(tf::createQuaternionFromRPY( 0, 0, 0 ), tf::Point(0, 0, 0 ))),
+  laser_count_(0), private_nh_("~"), transform_thread_(NULL), seed_(seed), tf_(ros::Duration(max_duration_buffer))
+{
   init();
 }
 
@@ -245,6 +257,58 @@ void SlamGMapping::startLiveSlam()
   scan_filter_->registerCallback(boost::bind(&SlamGMapping::laserCallback, this, _1));
 
   transform_thread_ = new boost::thread(boost::bind(&SlamGMapping::publishLoop, this, transform_publish_period_));
+}
+
+void SlamGMapping::startReplay(std::string bag_fname, std::string scan_topic)
+{
+  double transform_publish_period;
+  ros::NodeHandle private_nh_("~");
+  entropy_publisher_ = private_nh_.advertise<std_msgs::Float64>("entropy", 1, true);
+  sst_ = node_.advertise<nav_msgs::OccupancyGrid>("map", 1, true);
+  sstm_ = node_.advertise<nav_msgs::MapMetaData>("map_metadata", 1, true);
+  ss_ = node_.advertiseService("dynamic_map", &SlamGMapping::mapCallback, this);
+  
+  rosbag::Bag bag;
+  bag.open(bag_fname, rosbag::bagmode::Read);
+  
+  std::vector<std::string> topics;
+  std::vector<std::string> topics_scan;
+  topics.push_back(std::string("/tf"));
+  rosbag::View view(bag, rosbag::TopicQuery(topics));
+  
+  // Saving all transforms from rosbag into tf buffer
+  foreach(rosbag::MessageInstance const m, view)
+  {
+    tf::tfMessage::ConstPtr cur_tf = m.instantiate<tf::tfMessage>();
+    if (cur_tf != NULL) {
+      for (size_t i = 0; i < cur_tf->transforms.size(); ++i)
+      {
+        geometry_msgs::TransformStamped transformStamped;
+        tf::StampedTransform stampedTf;
+        transformStamped = cur_tf->transforms[i];
+        tf::transformStampedMsgToTF(transformStamped, stampedTf);
+        tf_.setTransform(stampedTf);
+      }
+    }
+  }
+  
+  topics_scan.push_back(scan_topic); 
+  rosbag::View viewall(bag, rosbag::TopicQuery(topics_scan));
+  int i = 0;
+  foreach(rosbag::MessageInstance const m, viewall)
+  {
+    i+=1 ;
+    sensor_msgs::LaserScan::ConstPtr s = m.instantiate<sensor_msgs::LaserScan>();
+    if (s != NULL) {
+      if (!(ros::Time(s->header.stamp)).is_zero())
+      {
+        this->laserCallback(s);
+      }
+      // ignoring un-timestamped tf data 
+    }
+  }
+  
+  bag.close();
 }
 
 void SlamGMapping::publishLoop(double transform_publish_period){

--- a/gmapping/src/slam_gmapping.h
+++ b/gmapping/src/slam_gmapping.h
@@ -39,7 +39,7 @@ class SlamGMapping
 
     void init();
     void startLiveSlam();
-    void startReplay(std::string bag_fname, std::string scan_topic);
+    void startReplay(const std::string & bag_fname, std::string scan_topic);
     void publishTransform();
   
     void laserCallback(const sensor_msgs::LaserScan::ConstPtr& scan);

--- a/gmapping/src/slam_gmapping.h
+++ b/gmapping/src/slam_gmapping.h
@@ -34,10 +34,12 @@ class SlamGMapping
 {
   public:
     SlamGMapping();
+    SlamGMapping(unsigned long int seed, unsigned long int max_duration_buffer);
     ~SlamGMapping();
 
     void init();
     void startLiveSlam();
+    void startReplay(std::string bag_fname, std::string scan_topic);
     void publishTransform();
   
     void laserCallback(const sensor_msgs::LaserScan::ConstPtr& scan);

--- a/gmapping/src/slam_gmapping.h
+++ b/gmapping/src/slam_gmapping.h
@@ -36,6 +36,8 @@ class SlamGMapping
     SlamGMapping();
     ~SlamGMapping();
 
+    void init();
+    void startLiveSlam();
     void publishTransform();
   
     void laserCallback(const sensor_msgs::LaserScan::ConstPtr& scan);
@@ -121,5 +123,10 @@ class SlamGMapping
     double lasamplerange_;
     double lasamplestep_;
     
+    ros::NodeHandle private_nh_;
+    
+    unsigned long int seed_;
+    
+    double transform_publish_period_;
     double tf_delay_;
 };

--- a/gmapping/test/basic_localization_stage_replay.launch
+++ b/gmapping/test/basic_localization_stage_replay.launch
@@ -1,0 +1,9 @@
+<launch>
+  <param name="/use_sim_time" value="true"/>
+  <node pkg="gmapping" type="slam_gmapping_replay" name="slam_gmapping_replay" output="screen"
+        args="--bag_filename $(find gmapping)/test/basic_localization_stage_indexed.bag --scan_topic /base_scan"/>
+  <!--test time-limit="30" test-name="basic_localization_stage" pkg="gmapping" 
+        type="test_map.py" args="90.0"/-->
+  <!-- TODO: Fix the rtest to work with replay, for now it's not working -->
+  <test time-limit="30" test-name="map_data_test" pkg="gmapping" type="gmapping-rtest" args="90.0 0.05 4000 4000 0.005 0.010"/>
+</launch>


### PR DESCRIPTION
The aim is to provide a way to get exactly the same map after running
gmapping multiple times on the same rosbag file. It wasn't possible with the
tool 'rosbag play', indeed one missing laser scan could provide really
different results.

The pull-request is composed of two commits, the first one separate init code from construction code. The second one introduced the replay on bag_file.

Concerning the automatic test, please see test/basic_localization_stage_replay.launch , I need help to get a working test here, not sure about how to handle time as we are no more using rosbag play here, so if you have time to have a look (I didn't manage to have something that works concerning the automatic test part, but the code works fine on rosbag in my daily use).
