### PR TITLE
Some fixes and tweaks

### DIFF
--- a/gmapping/src/replay.cpp
+++ b/gmapping/src/replay.cpp
@@ -34,7 +34,8 @@ main(int argc, char** argv)
     ("scan_topic",  po::value<std::string>()->default_value("/scan") ,"topic that contains the laserScan in the rosbag")
     ("bag_filename", po::value<std::string>()->required(), "ros bag filename") 
     ("seed", po::value<unsigned long int>()->default_value(0), "seed")
-    ("max_duration_buffer", po::value<unsigned long int>()->default_value(99999), "max tf buffer duration") ;
+    ("max_duration_buffer", po::value<unsigned long int>()->default_value(99999), "max tf buffer duration")
+    ("on_done", po::value<std::string>(), "command to execute when done") ;
     
     po::variables_map vm; 
     try 
@@ -71,7 +72,15 @@ main(int argc, char** argv)
     gn.startReplay(bag_fname, scan_topic);
     ROS_INFO("replay stopped.");
 
-    ros::spin(); // wait so user can save the map
+    if ( vm.count("on_done") )
+    {
+        // Run the "on_done" command and then exit
+        system(vm["on_done"].as<std::string>().c_str());
+    }
+    else
+    {
+        ros::spin(); // wait so user can save the map
+    }
     return(0);
     
     

--- a/gmapping/src/slam_gmapping.cpp
+++ b/gmapping/src/slam_gmapping.cpp
@@ -129,7 +129,7 @@ Initial map dimensions and resolution:
 
 SlamGMapping::SlamGMapping():
   map_to_odom_(tf::Transform(tf::createQuaternionFromRPY( 0, 0, 0 ), tf::Point(0, 0, 0 ))),
-  laser_count_(0), private_nh_("~"), transform_thread_(NULL)
+  laser_count_(0), private_nh_("~"), scan_filter_sub_(NULL), scan_filter_(NULL), transform_thread_(NULL)
 {
   seed_ = time(NULL);
   init();
@@ -137,7 +137,8 @@ SlamGMapping::SlamGMapping():
 
 SlamGMapping::SlamGMapping(long unsigned int seed, long unsigned int max_duration_buffer):
   map_to_odom_(tf::Transform(tf::createQuaternionFromRPY( 0, 0, 0 ), tf::Point(0, 0, 0 ))),
-  laser_count_(0), private_nh_("~"), transform_thread_(NULL), seed_(seed), tf_(ros::Duration(max_duration_buffer))
+  laser_count_(0), private_nh_("~"), scan_filter_sub_(NULL), scan_filter_(NULL), transform_thread_(NULL),
+  seed_(seed), tf_(ros::Duration(max_duration_buffer))
 {
   init();
 }

--- a/gmapping/src/slam_gmapping.cpp
+++ b/gmapping/src/slam_gmapping.cpp
@@ -276,6 +276,7 @@ void SlamGMapping::startReplay(const std::string & bag_fname, std::string scan_t
   topics.push_back(scan_topic);
   rosbag::View viewall(bag, rosbag::TopicQuery(topics));
 
+  bool at_startup = true;
   std::queue<sensor_msgs::LaserScan::ConstPtr> s_queue;
   foreach(rosbag::MessageInstance const m, viewall)
   {
@@ -309,11 +310,27 @@ void SlamGMapping::startReplay(const std::string & bag_fname, std::string scan_t
         tf_.lookupTransform(s_queue.front()->header.frame_id, odom_frame_, s_queue.front()->header.stamp, t);
         this->laserCallback(s_queue.front());
         s_queue.pop();
+        at_startup = false;
       }
-      // If tf does not have the data yet
+      // Drop laser scan if tf does not have the data yet (should only happen at startup)
       catch(tf::ExtrapolationException& e)
       {
-        break;
+        if (at_startup) {
+          s_queue.pop();
+          break;
+        } else {
+          throw e;
+        }
+      }
+      // Try again next time if tf does not have the data for the laser frame yet
+      // (should only happen at startup)
+      catch(tf::LookupException& e)
+      {
+        if (at_startup) {
+          break;
+        } else {
+          throw e;
+        }
       }
     }
   }


### PR DESCRIPTION
I ran into a few issues while using the replay feature of slam_gmapping:
- The order of TF frames and laser scans in my bag file was such that the first laser scan came in before the first (static) laser transform.  So TF barfed on that (with a LookupException).
- Furthermore (and on a related note) the timestamp in my laser frame was earlier than that of the  first laser transform, so TF couldn't interpolate from non-existent data.

I fixed both of these issues by ignoring these sorts of problems at startup, but (being the paranoid programmer I am), throwing an exception should they ever occur in the middle of processing a bag file.
- I added an "on_done" command line parameter that I use to automatically save the map and and exit from replay at the end of the bag file.
- I fixed a bug where replay would crash and dump core (as it attempted to delete a couple of uninitialized pointers)

Please tell me what you think, or feel free to just merge this pull request.

--wpd
