### PR TITLE
Add better message for scan range error

### DIFF
--- a/gmapping/src/slam_gmapping.cpp
+++ b/gmapping/src/slam_gmapping.cpp
@@ -406,9 +406,9 @@ SlamGMapping::initMapper(const sensor_msgs::LaserScan& scan)
   }
 
   // Check that laserscan is from -x to x in angles:
-  if (fabs(fabs(scan.angle_min) - fabs(scan.angle_max)) > FLT_EPSILON)
+  if (fabs(fabs(scan.angle_min) - fabs(scan.angle_max)) > FLT_EPSILON)  
   {
-    ROS_ERROR("Scan message must contain angles from -x to x, i.e. angle_min = -angle_max");
+    ROS_ERROR("Scan message must contain angles from -x to x, i.e. angle_min = -angle_max\n\t   fabs(fabs(scan.angle_min)) - fabs(scan.angle_max)) > FLT_EPSILON\n\t=> fabs(%f - %f) = %f > %f", fabs(scan.angle_min), fabs(scan.angle_max), fabs(fabs(scan.angle_min) - fabs(scan.angle_max)), FLT_EPSILON);
     return false;
   }
 


### PR DESCRIPTION
As reported in [this QA](http://answers.ros.org/question/210849/scan-message-must-contain-angles-from-x-to-x/), `turtlebot_gazebo` exits with error with gmapping 1.3.7. This PR is trying to give the users better idea of the error like below:

```
[ERROR] [1437021913.484787538, 1026.770000000]: Scan message must contain angles from -x to x, i.e. angle_min = -angle_max
    (A) fabs(fabs(scan.angle_min)): 0.521568, (B) fabs(scan.angle_max)): 0.524276
    fabs(A - B) = 0.002708 > FLT_EPSILON: 0.000000
[ERROR] [1437021913.588470210, 1026.870000000]: Scan message must contain angles from -x to x, i.e. angle_min = -angle_max
    (A) fabs(fabs(scan.angle_min)): 0.521568, (B) fabs(scan.angle_max)): 0.524276
    fabs(A - B) = 0.002708 > FLT_EPSILON: 0.000000
[ERROR] [1437021913.688704627, 1026.970000000]: Scan message must contain angles from -x to x, i.e. angle_min = -angle_max
    (A) fabs(fabs(scan.angle_min)): 0.521568, (B) fabs(scan.angle_max)): 0.524276
    fabs(A - B) = 0.002708 > FLT_EPSILON: 0.000000
```

---

But the real question here lies [in this line](https://github.com/ros-perception/slam_gmapping/pull/26/files#diff-ee79bfdef4f6452c01f74517ee41c050R314); setting `FLT_EPSILON` as the criteria might be too strict as far as I see the result from turtlebot_gazebo as above. @windelbouwman Would you give some comments on this?
