### PR TITLE
Add missing nodelet dependency to find_package

### DIFF
--- a/gmapping/CMakeLists.txt
+++ b/gmapping/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 project(gmapping)
 
-find_package(catkin REQUIRED nav_msgs openslam_gmapping roscpp rostest tf rosbag_storage)
+find_package(catkin REQUIRED nav_msgs openslam_gmapping roscpp rostest tf rosbag_storage nodelet)
 
 find_package(Boost REQUIRED signals)
 


### PR DESCRIPTION
The nodelet package was listed in package.xml but not included in the CMakeList.  This causes a linker error when building on OSX.