### PR TITLE
Install nodelet plugin descriptor file as well.

### DIFF
--- a/gmapping/CMakeLists.txt
+++ b/gmapping/CMakeLists.txt
@@ -32,6 +32,10 @@ install(TARGETS slam_gmapping slam_gmapping_replay
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
+install(FILES nodelet_plugins.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
   if(TARGET tests)


### PR DESCRIPTION
This seems to have been missed in #41.

Related ROS Answers question: [pointcloud_to_laserscan: "Skipping XML Document..."](https://answers.ros.org/question/274849) (note that the problem is here, in `gmapping`, not in `pointcloud_to_laserscan`).

Fixes #55.

Without this, from-source builds in `devel` spaces will work fine, but the binary debians will not contain the required plugin descriptor file.

This will need a new release on all platforms.
