### PR TITLE
Fix compilation on Windows

### DIFF
--- a/gmapping/CMakeLists.txt
+++ b/gmapping/CMakeLists.txt
@@ -3,7 +3,7 @@ project(gmapping)
 
 find_package(catkin REQUIRED nav_msgs nodelet openslam_gmapping roscpp tf rosbag_storage)
 
-find_package(Boost REQUIRED)
+find_package(Boost COMPONENTS thread system program_options REQUIRED)
 
 include_directories(${Boost_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
 


### PR DESCRIPTION
Otherwise linker errors occur:
```
FAILED: devel/lib/gmapping/slam_gmapping_replay.exe 
cmd.exe /C "cd . && %BUILD_PREFIX%\Library\bin\cmake.exe -E vs_link_exe --intdir=CMakeFiles\slam_gmapping_replay.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100177~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100177~1.0\x64\mt.exe --manifests  -- C:\PROGRA~2\MICROS~1\2017\ENTERP~1\VC\Tools\MSVC\1416~1.270\bin\Hostx64\x64\link.exe /nologo @CMakeFiles\slam_gmapping_replay.rsp  /out:devel\lib\gmapping\slam_gmapping_replay.exe /implib:devel\lib\slam_gmapping_replay.lib /pdb:devel\lib\gmapping\slam_gmapping_replay.pdb /version:0.0 /machine:x64 /INCREMENTAL:NO /subsystem:console  && cd ."
LINK: command "C:\PROGRA~2\MICROS~1\2017\ENTERP~1\VC\Tools\MSVC\1416~1.270\bin\Hostx64\x64\link.exe /nologo @CMakeFiles\slam_gmapping_replay.rsp /out:devel\lib\gmapping\slam_gmapping_replay.exe /implib:devel\lib\slam_gmapping_replay.lib /pdb:devel\lib\gmapping\slam_gmapping_replay.pdb /version:0.0 /machine:x64 /INCREMENTAL:NO /subsystem:console /MANIFEST /MANIFESTFILE:devel\lib\gmapping\slam_gmapping_replay.exe.manifest" failed (exit code 1120) with the following output:
replay.cpp.obj : error LNK2019: unresolved external symbol "class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > boost::program_options::arg" (?arg@program_options@boost@@3V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@A) referenced in function "public: virtual class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > __cdecl boost::program_options::typed_value<unsigned long,char>::name(void)const " (?name@?$typed_value@KD@program_options@boost@@UEBA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@XZ)
replay.cpp.obj : error LNK2019: unresolved external symbol "public: static unsigned int const boost::program_options::options_description::m_default_line_length" (?m_default_line_length@options_description@program_options@boost@@2IB) referenced in function main
devel\lib\gmapping\slam_gmapping_replay.exe : fatal error LNK1120: 2 unresolved externals
```