### PR TITLE
[ROS-O] drop deprecated use of boost::bind's _1

### DIFF
--- a/gmapping/src/slam_gmapping.cpp
+++ b/gmapping/src/slam_gmapping.cpp
@@ -274,7 +274,7 @@ void SlamGMapping::startLiveSlam()
   ss_ = node_.advertiseService("dynamic_map", &SlamGMapping::mapCallback, this);
   scan_filter_sub_ = new message_filters::Subscriber<sensor_msgs::LaserScan>(node_, "scan", 5);
   scan_filter_ = new tf::MessageFilter<sensor_msgs::LaserScan>(*scan_filter_sub_, tf_, odom_frame_, 5);
-  scan_filter_->registerCallback(boost::bind(&SlamGMapping::laserCallback, this, _1));
+  scan_filter_->registerCallback([this](auto msg){ laserCallback(msg); });
 
   transform_thread_ = new boost::thread(boost::bind(&SlamGMapping::publishLoop, this, transform_publish_period_));
 }


### PR DESCRIPTION
using a lambda is encouraged from c++11.

This breaks with a recent [ROS-O] proposal to adapt a ros_comm header include API. https://github.com/ros-o/ros_comm/pull/3

@k-okada: Could you consider merging here or adding me as fellow orphaned package maintainer?